### PR TITLE
Move string-child conversion before uid-assignment

### DIFF
--- a/src/abn_tree_directive.coffee
+++ b/src/abn_tree_directive.coffee
@@ -1,4 +1,3 @@
-
 module = angular.module 'angularBootstrapNavTree',[]
 
 module.directive 'abnTree',['$timeout',($timeout)-> 
@@ -144,23 +143,7 @@ module.directive 'abnTree',['$timeout',($timeout)->
     on_treeData_change = ->
 
       #console.log 'tree-data-change!'
-
-      # give each Branch a UID ( to keep AngularJS happy )
-      for_each_branch (b,level)->
-        if not b.uid
-          b.uid = ""+Math.random()
-      console.log 'UIDs are set.'
-
-
-      # set all parents:
-      for_each_branch (b)->
-        if angular.isArray b.children
-          for child in b.children
-            child.parent_uid = b.uid
-
-
-      scope.tree_rows = []
-
+      
       #
       # if "children" is just a list of strings...
       # ...change them into objects:
@@ -179,6 +162,23 @@ module.directive 'abnTree',['$timeout',($timeout)->
 
         else
           branch.children = []
+
+
+      # give each Branch a UID ( to keep AngularJS happy )
+      for_each_branch (b,level)->
+        if not b.uid
+          b.uid = ""+Math.random()
+      console.log 'UIDs are set.'
+
+
+      # set all parents:
+      for_each_branch (b)->
+        if angular.isArray b.children
+          for child in b.children
+            child.parent_uid = b.uid
+
+
+      scope.tree_rows = []
 
       
       #


### PR DESCRIPTION
Setting UID's to branches should happen after the plain-string typed leaves are converted to objects. Otherwise the uid for those leaves is not set and Angular outputs the "ngRepeat:dupes" error. The bug can be reproduced by changing the "expand-level" attribute to "3" on the test pages (at least on bs3/ng120)

The angular error: Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: row in tree_rows | filter:{visible:true} track by row.branch.uid, Duplicate key: undefined
