### PR TITLE
Remove console.log for trivial messages.

### DIFF
--- a/src/abn_tree_directive.js
+++ b/src/abn_tree_directive.js
@@ -139,7 +139,6 @@ module.directive('abnTree', [
               return b.uid = "" + Math.random();
             }
           });
-          console.log('UIDs are set.');
           for_each_branch(function(b) {
             var child, _i, _len, _ref, _results;
             if (angular.isArray(b.children)) {
@@ -233,7 +232,6 @@ module.directive('abnTree', [
           });
         }
         n = scope.treeData.length;
-        console.log('num root branches = ' + n);
         for_each_branch(function(b, level) {
           b.level = level;
           return b.expanded = b.level < expand_level;


### PR DESCRIPTION
Writing trivial messages to the console pollutes the log, making it harder to see what is going on. We should use $log instead for other important messages or error logs.
