### PR TITLE
Added option to specify node-specific icons. Fixes nickperkinslondon/angular-bootstrap-nav-tree#21

### DIFF
--- a/dist/abn_tree_directive.js
+++ b/dist/abn_tree_directive.js
@@ -135,25 +135,6 @@
           scope.tree_rows = [];
           on_treeData_change = function() {
             var add_branch_to_list, root_branch, _i, _len, _ref, _results;
-            for_each_branch(function(b, level) {
-              if (!b.uid) {
-                return b.uid = "" + Math.random();
-              }
-            });
-            console.log('UIDs are set.');
-            for_each_branch(function(b) {
-              var child, _i, _len, _ref, _results;
-              if (angular.isArray(b.children)) {
-                _ref = b.children;
-                _results = [];
-                for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-                  child = _ref[_i];
-                  _results.push(child.parent_uid = b.uid);
-                }
-                return _results;
-              }
-            });
-            scope.tree_rows = [];
             for_each_branch(function(branch) {
               var child, f;
               if (branch.children) {
@@ -183,6 +164,25 @@
                 return branch.children = [];
               }
             });
+            for_each_branch(function(b, level) {
+              if (!b.uid) {
+                return b.uid = "" + Math.random();
+              }
+            });
+            console.log('UIDs are set.');
+            for_each_branch(function(b) {
+              var child, _i, _len, _ref, _results;
+              if (angular.isArray(b.children)) {
+                _ref = b.children;
+                _results = [];
+                for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+                  child = _ref[_i];
+                  _results.push(child.parent_uid = b.uid);
+                }
+                return _results;
+              }
+            });
+            scope.tree_rows = [];
             add_branch_to_list = function(level, branch, visible) {
               var child, child_visible, tree_icon, _i, _len, _ref, _results;
               if (branch.expanded == null) {
@@ -192,15 +192,15 @@
                 branch.classes = [];
               }
               if (!branch.noLeaf && (!branch.children || branch.children.length === 0)) {
-                tree_icon = attrs.iconLeaf;
+                tree_icon = branch.iconLeaf ? branch.iconLeaf : attrs.iconLeaf;
                 if (__indexOf.call(branch.classes, "leaf") < 0) {
                   branch.classes.push("leaf");
                 }
               } else {
                 if (branch.expanded) {
-                  tree_icon = attrs.iconCollapse;
+                  tree_icon = branch.iconCollapse ? branch.iconCollapse : attrs.iconCollapse;
                 } else {
-                  tree_icon = attrs.iconExpand;
+                  tree_icon = branch.iconExpand ? branch.iconExpand : attrs.iconExpand;
                 }
               }
               scope.tree_rows.push({

--- a/src/abn_tree_directive.coffee
+++ b/src/abn_tree_directive.coffee
@@ -199,13 +199,13 @@ module.directive 'abnTree',['$timeout',($timeout)->
         # <i class="icon-plus"></i>
         #
         if not branch.noLeaf and (not branch.children or branch.children.length == 0)
-          tree_icon = attrs.iconLeaf
+          tree_icon = if branch.iconLeaf then branch.iconLeaf else attrs.iconLeaf
           branch.classes.push "leaf" if "leaf" not in branch.classes
         else
           if branch.expanded
-            tree_icon = attrs.iconCollapse
+            tree_icon = if branch.iconCollapse then branch.iconCollapse else attrs.iconCollapse
           else
-            tree_icon = attrs.iconExpand 
+            tree_icon = if branch.iconExpand then branch.iconExpand else attrs.iconExpand
 
 
         #

--- a/test/test_page.coffee
+++ b/test/test_page.coffee
@@ -87,15 +87,20 @@ app.controller 'AbnTestController',($scope,$timeout)->
       label:'Oranges'
     ,
       label:'Apples'
+      iconCollapse: 'icon-hand-down glyphicon glyphicon-hand-down fa fa-hand-down'
+      iconExpand: 'icon-hand-right  glyphicon glyphicon-hand-right  fa fa-hand-right'
       children:[
         label:'Granny Smith'
         onSelect:apple_selected
+        iconLeaf:'icon-heart-empty  glyphicon glyphicon-heart-empty  fa fa-heart-empty'
       ,
         label:'Red Delicous'
         onSelect:apple_selected
+        iconLeaf:'icon-star  glyphicon glyphicon-star  fa fa-star'
       ,
         label:'Fuji'
         onSelect:apple_selected
+        iconLeaf:'icon-music  glyphicon glyphicon-music  fa fa-music'
       ]
     ]
   ,

--- a/test/test_page.js
+++ b/test/test_page.js
@@ -59,16 +59,21 @@
             label: 'Oranges'
           }, {
             label: 'Apples',
+            iconCollapse: 'icon-hand-down glyphicon glyphicon-hand-down fa fa-hand-down',
+            iconExpand: 'icon-hand-right  glyphicon glyphicon-hand-right  fa fa-hand-right',
             children: [
               {
                 label: 'Granny Smith',
-                onSelect: apple_selected
+                onSelect: apple_selected,
+                iconLeaf: 'icon-heart-empty  glyphicon glyphicon-heart-empty  fa fa-heart-empty'
               }, {
                 label: 'Red Delicous',
-                onSelect: apple_selected
+                onSelect: apple_selected,
+                iconLeaf: 'icon-star  glyphicon glyphicon-star  fa fa-star'
               }, {
                 label: 'Fuji',
-                onSelect: apple_selected
+                onSelect: apple_selected,
+                iconLeaf: 'icon-music  glyphicon glyphicon-music  fa fa-music'
               }
             ]
           }


### PR DESCRIPTION
Hi @nickperkinslondon,

We needed the option of defining node-specific icons for displaying the type of a node. This solves nickperkinslondon/angular-bootstrap-nav-tree#21.

Best regards

Matt
