### PR TITLE
Avoid duplicating warning in ng-repeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+.idea/
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use the following syntax:
 
 The data to create the tree is defined in your controller, and could be as simple as this:
 
-    $scope.my_data = [{
+    $scope.my_treedata = [{
       label: 'Languages',
       children: ['Jade','Less','Coffeescript']
     }]
@@ -66,7 +66,7 @@ long-form, where is branch is an object, then you can also attach "data" to a br
 
 If you would like to add classes to a certain node, give it an array of classes like so:
 
-    $scope.my_data = [{
+    $scope.my_treedata = [{
       label: 'Languages',
       children: ['Jade','Less','Coffeescript']
       classes: ["special", "red"]
@@ -86,7 +86,7 @@ You can supply a single default "on-select" function for the whole tree -- it wi
 
 Or, you can put a custom "on-select" function on an individual branch:
 
-    $scope.my_data = [{
+    $scope.my_treedata = [{
       label: 'Languages',
       onSelect: function(branch){...},
       children: ['Jade','Less','Coffeescript']

--- a/dist/abn_tree_directive.js
+++ b/dist/abn_tree_directive.js
@@ -8,7 +8,7 @@
     '$timeout', function($timeout) {
       return {
         restrict: 'E',
-        template: "<ul class=\"nav nav-list nav-pills nav-stacked abn-tree\">\n  <li ng-repeat=\"row in tree_rows | filter:{visible:true} track by row.branch.uid\" ng-animate=\"'abn-tree-animate'\" ng-class=\"'level-' + {{ row.level }} + (row.branch.selected ? ' active':'') + ' ' +row.classes.join(' ')\" class=\"abn-tree-row\"><a ng-click=\"user_clicks_branch(row.branch)\"><i ng-class=\"row.tree_icon\" ng-click=\"row.branch.expanded = !row.branch.expanded\" class=\"indented tree-icon\"> </i><span class=\"indented tree-label\">{{ row.label }} </span></a></li>\n</ul>",
+        template: "<ul class=\"nav nav-list nav-pills nav-stacked abn-tree\">\n  <li ng-repeat=\"row in tree_rows | filter:{visible:true} track by row.branch.uid || '~' + $index\" ng-animate=\"'abn-tree-animate'\" ng-class=\"'level-' + {{ row.level }} + (row.branch.selected ? ' active':'') + ' ' +row.classes.join(' ')\" class=\"abn-tree-row\"><a ng-click=\"user_clicks_branch(row.branch)\"><i ng-class=\"row.tree_icon\" ng-click=\"row.branch.expanded = !row.branch.expanded\" class=\"indented tree-icon\"> </i><span class=\"indented tree-label\">{{ row.label }} </span></a></li>\n</ul>",
         replace: true,
         scope: {
           treeData: '=',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "angular-bootstrap-nav-tree",
   "version": "0.2.0",
+  "repository":{
+    "type":"git",
+    "url":"git://github.com/nickperkinslondon/angular-bootstrap-nav-tree"
+  },
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -10,5 +14,5 @@
     "grunt-string-replace": "~0.2.7"
   },
   "keywords":["angularjs","bootstrap","tree","widget"],
-  "licence":"MIT"
+  "license":"MIT"
 }

--- a/src/abn_tree_template.jade
+++ b/src/abn_tree_template.jade
@@ -2,7 +2,7 @@
 ul.nav.nav-list.nav-pills.nav-stacked.abn-tree
 
   li.abn-tree-row(
-    ng-repeat='row in tree_rows | filter:{visible:true} track by row.branch.uid'
+    ng-repeat='row in tree_rows | filter:{visible:true} track by row.branch.uid || \'~\' + $index'
     ng-animate="'abn-tree-animate'"
     ng-class="'level-' + {{ row.level }} + (row.branch.selected ? ' active':'') + ' ' +row.classes.join(' ')"
     )


### PR DESCRIPTION
1. Add " '~' + $index" in the following line:
   
   `<li ng-repeat = "row in tree_rows | filter...track by row.branch.uid || '~' + $index">`
   
   When row.branch.uid is empty, ng-repeat error will occur: "Duplicates in a repeater are not allowed".
2. Fix the variables of the example in README.
   
   `<abn-tree tree-data         = "my_treedata" ...>`
   
   ``` js
   $scope.my_treedata = [{ // Replace 'my_data' with 'my_treedata'
     label: 'Languages',
     children: ['Jade','Less','Coffeescript']
   }]
   ```
3. Add repository and fix license in package.son (`licence` -> `license`).
